### PR TITLE
fix: use correct uplift v2 schema format

### DIFF
--- a/.uplift.yml
+++ b/.uplift.yml
@@ -3,26 +3,32 @@
 
 # Semantic versioning bumps based on commit types
 bumps:
-  # Major version bumps for breaking changes
-  - file: "**"
-    regex: "BREAKING CHANGE|!:"
+  - regex:
+      - "BREAKING CHANGE"
+      - "!:"
     type: "major"
   
-  # Minor version bumps for new features
-  - file: "**"  
-    regex: "^feat|^feature"
+  - regex:
+      - "^feat"
+      - "^feature"
     type: "minor"
     
-  # Patch version bumps for fixes and other changes
-  - file: "**"
-    regex: "^fix|^chore|^docs|^style|^refactor|^perf|^test|^ci|^build"
+  - regex:
+      - "^fix"
+      - "^chore" 
+      - "^docs"
+      - "^style"
+      - "^refactor"
+      - "^perf"
+      - "^test"
+      - "^ci"
+      - "^build"
     type: "patch"
 
 # Git configuration
 git:
   ignoreDetached: false
 
-# Environment variables required
+# Environment variables
 env:
-  - name: "GITHUB_TOKEN"
-    required: true
+  GITHUB_TOKEN: true


### PR DESCRIPTION
- Remove 'file' field from bumps (not supported in v2)
- Use regex arrays instead of single regex strings
- Fix env section to use key: value format instead of array
- Remove 'type' field nesting issues
- This should resolve the YAML unmarshaling errors in uplift